### PR TITLE
Updated SPARQL Count query to confirm to the standard syntax:

### DIFF
--- a/lib/datasources/SparqlDatasource.js
+++ b/lib/datasources/SparqlDatasource.js
@@ -74,8 +74,8 @@ SparqlDatasource.prototype._getPatternCount = function (sparqlPattern, callback)
   var countResponse = this._request({
     url: this._endpointUrl + encodeURIComponent(this._createCountQuery(sparqlPattern)),
     //This should be one of the formats supported by http://www.w3.org/TR/sparql11-overview/#sparql11-results
-    //Default to the CSV type
-    headers: { accept: 'text/csv;q=1.0,application/sparql-results+xml;q=0.5,application/sparql-results+json;q=0.3'},
+    //Only support the CSV type
+    headers: { accept: 'text/csv;q=1.0'},
     timeout: 7500,
   }, callback);
   countResponse.on('error', callback);
@@ -89,15 +89,14 @@ SparqlDatasource.prototype._getPatternCount = function (sparqlPattern, callback)
 	});
 
   countResponse.on('end', function() {
-       var split = data.split("\n");
-       if(split.length > 1) {
-          console.log(split[1]);
-          count = parseInt(split[1], 10);
-  	  if (count > 100000) cache.set(sparqlPattern, count);
-          callback(null, count);
-       } else {
-	 new Error("No count returned.");
-       }
+    var split = data.split("\n");
+    if(split.length > 1) {
+       count = parseInt(split[1], 10);
+  	if (count > 100000) cache.set(sparqlPattern, count);
+       callback(null, count);
+    } else {
+	   return callback(new Error("No count returned."));
+    }
   });
 };
 

--- a/lib/datasources/SparqlDatasource.js
+++ b/lib/datasources/SparqlDatasource.js
@@ -73,22 +73,31 @@ SparqlDatasource.prototype._getPatternCount = function (sparqlPattern, callback)
   // Execute the count query
   var countResponse = this._request({
     url: this._endpointUrl + encodeURIComponent(this._createCountQuery(sparqlPattern)),
-    headers: { accept: 'text/turtle;q=1.0,text/ntriples;q=0.5,text/n3;q=0.3' },
+    //This should be one of the formats supported by http://www.w3.org/TR/sparql11-overview/#sparql11-results
+    //Default to the CSV type
+    headers: { accept: 'text/csv;q=1.0,application/sparql-results+xml;q=0.5,application/sparql-results+json;q=0.3'},
     timeout: 7500,
   }, callback);
   countResponse.on('error', callback);
 
-  // Find the triple that contains the count
-  N3.Parser().parse(countResponse, function (error, triple) {
-    if (error) return callback(new Error(INVALID_TURTLE_RESPONSE));
-    if (triple && triple.predicate === 'http://www.w3.org/2005/sparql-results#value') {
-      // If a count is found, we don't need to parse the reminder of the document
-      countResponse.abort();
-      // Cache large values; small ones are calculated fast anyway
-      count = parseInt(N3.Util.getLiteralValue(triple.object), 10);
-      if (count > 100000) cache.set(sparqlPattern, count);
-      callback(null, count);
-    }
+  //Expecting 2 line format if it is successful
+  //count
+  //1342342343
+  var data = '';
+  countResponse.on('data', function(chunk) {
+  	data += chunk;
+	});
+
+  countResponse.on('end', function() {
+       var split = data.split("\n");
+       if(split.length > 1) {
+          console.log(split[1]);
+          count = parseInt(split[1], 10);
+  	  if (count > 100000) cache.set(sparqlPattern, count);
+          callback(null, count);
+       } else {
+	 new Error("No count returned.");
+       }
   });
 };
 
@@ -107,7 +116,7 @@ SparqlDatasource.prototype._createConstructQuery =  function (sparqlPattern, off
 
 // Creates a SELECT COUNT(*) query from the given SPARQL pattern
 SparqlDatasource.prototype._createCountQuery = function (sparqlPattern) {
-  return ['SELECT COUNT(*)', 'WHERE', sparqlPattern].join(' ');
+  return ['SELECT (COUNT(*) as ?count)', 'WHERE', sparqlPattern].join(' ');
 };
 
 // Creates a SPARQL pattern for the given triple pattern

--- a/test/datasources/SparqlDatasource-test.js
+++ b/test/datasources/SparqlDatasource-test.js
@@ -64,7 +64,7 @@ describe('SparqlDatasource', function () {
       'the empty query',
       { features: { triplePattern: true } },
       'CONSTRUCT {?s ?p ?o} WHERE {?s ?p ?o}',
-      'SELECT COUNT(*) WHERE {?s ?p ?o}');
+      'SELECT (COUNT(*) as ?count) WHERE {?s ?p ?o}');
 
     itShouldExecute(datasource, request,
       'an empty query with a limit',
@@ -82,44 +82,44 @@ describe('SparqlDatasource', function () {
       'a query for a subject IRI',
       { subject: 'http://example.org/bar#foo', features: { triplePattern: true } },
       'CONSTRUCT {<http://example.org/bar#foo> ?p ?o} WHERE {<http://example.org/bar#foo> ?p ?o}',
-      'SELECT COUNT(*) WHERE {<http://example.org/bar#foo> ?p ?o}');
+      'SELECT (COUNT(*) as ?count) WHERE {<http://example.org/bar#foo> ?p ?o}');
 
     itShouldExecute(datasource, request,
       'a query for a predicate IRI',
       { predicate: 'http://example.org/bar#foo', features: { triplePattern: true } },
       'CONSTRUCT {?s <http://example.org/bar#foo> ?o} WHERE {?s <http://example.org/bar#foo> ?o}',
-      'SELECT COUNT(*) WHERE {?s <http://example.org/bar#foo> ?o}');
+      'SELECT (COUNT(*) as ?count) WHERE {?s <http://example.org/bar#foo> ?o}');
 
     itShouldExecute(datasource, request,
       'a query for an object IRI',
       { object: 'http://example.org/bar#foo', features: { triplePattern: true } },
       'CONSTRUCT {?s ?p <http://example.org/bar#foo>} WHERE {?s ?p <http://example.org/bar#foo>}',
-      'SELECT COUNT(*) WHERE {?s ?p <http://example.org/bar#foo>}');
+      'SELECT (COUNT(*) as ?count) WHERE {?s ?p <http://example.org/bar#foo>}');
 
     itShouldExecute(datasource, request,
       'a query for an object literal',
       { object: '"a literal"', features: { triplePattern: true } },
       'CONSTRUCT {?s ?p "a literal"} WHERE {?s ?p "a literal"}',
-      'SELECT COUNT(*) WHERE {?s ?p "a literal"}');
+      'SELECT (COUNT(*) as ?count) WHERE {?s ?p "a literal"}');
 
     itShouldExecute(datasource, request,
       'a query for an object literal with newlines and quotes',
       { object: '"a\rb\nc"\r\n\\""', features: { triplePattern: true } },
       'CONSTRUCT {?s ?p """a\rb\nc\\"\r\n\\\\\\""""} WHERE {?s ?p """a\rb\nc\\"\r\n\\\\\\""""}',
-      'SELECT COUNT(*) WHERE {?s ?p """a\rb\nc\\"\r\n\\\\\\""""}');
+      'SELECT (COUNT(*) as ?count) WHERE {?s ?p """a\rb\nc\\"\r\n\\\\\\""""}');
 
     itShouldExecute(datasource, request,
       'a query for an object literal with a language',
       { object: '"a literal"@nl-be', features: { triplePattern: true } },
       'CONSTRUCT {?s ?p "a literal"@nl-be} WHERE {?s ?p "a literal"@nl-be}',
-      'SELECT COUNT(*) WHERE {?s ?p "a literal"@nl-be}');
+      'SELECT (COUNT(*) as ?count)  WHERE {?s ?p "a literal"@nl-be}');
 
     itShouldExecute(datasource, request,
       'a query for an object literal with a type',
       { object: '"a literal"^^http://ex.org/foo#literal', features: { triplePattern: true } },
       'CONSTRUCT {?s ?p "a literal"^^<http://ex.org/foo#literal>} ' +
           'WHERE {?s ?p "a literal"^^<http://ex.org/foo#literal>}',
-      'SELECT COUNT(*) WHERE {?s ?p "a literal"^^<http://ex.org/foo#literal>}');
+      'SELECT (COUNT(*) as ?count) WHERE {?s ?p "a literal"^^<http://ex.org/foo#literal>}');
 
     itShouldExecute(datasource, request,
       'a query for a predicate and object URI',
@@ -128,7 +128,7 @@ describe('SparqlDatasource', function () {
         features: { triplePattern: true } },
       'CONSTRUCT {?s <http://example.org/bar#foo> <http://example.org/baz#bar>} ' +
           'WHERE {?s <http://example.org/bar#foo> <http://example.org/baz#bar>}',
-      'SELECT COUNT(*) WHERE {?s <http://example.org/bar#foo> <http://example.org/baz#bar>}');
+      'SELECT (COUNT(*) as ?count) WHERE {?s <http://example.org/bar#foo> <http://example.org/baz#bar>}');
 
     itShouldExecute(datasource, request,
       'a query for a predicate and object URI with offset and limit',
@@ -171,7 +171,7 @@ describe('SparqlDatasource', function () {
         request.should.have.been.calledThrice;
         var url = URL.parse(request.secondCall.args[0].url, true);
         (url.protocol + '//' + url.host + url.pathname).should.equal('http://ex.org/sparql');
-        url.query.query.should.equal('SELECT COUNT(*) WHERE {<abc> ?p ?o}');
+        url.query.query.should.equal('SELECT (COUNT(*) as ?count) WHERE {<abc> ?p ?o}');
       });
 
       it('should request a matching CONSTRUCT query the second time', function () {


### PR DESCRIPTION
We had a user working with Blazegraph and the ldf-server and encountered a couple of minor standards issues.  This PR is to update those.

```
[9]     SelectClause      ::=   'SELECT' ( 'DISTINCT' | 'REDUCED' )? ( ( Var | ( '(' Expression 'AS' Var ')' ) )+ | '*' )
```

Updated count query results to use the text/csv response type rather than expecting a turtle serialization.