### PR TITLE
Add support for X-Forward-Host/Proto HTTP headers

### DIFF
--- a/lib/controllers/Controller.js
+++ b/lib/controllers/Controller.js
@@ -4,7 +4,8 @@
 var url = require('url'),
     _ = require('lodash'),
     ViewCollection = require('../views/ViewCollection'),
-    Util = require('../Util');
+    Util = require('../Util'),
+    parseForwarded = require('forwarded-parse');
 
 // Creates a new Controller
 function Controller(options) {
@@ -36,7 +37,10 @@ Controller.prototype.handleRequest = function (request, response, next, settings
   if (!request.parsedUrl) {
     // Keep the request's path and query, but take over all other defined baseURL properties
     request.parsedUrl = _.defaults(_.pick(url.parse(request.url, true), 'path', 'pathname', 'query'),
-                                   this._baseUrl, { protocol: 'http:', host: request.headers.host });
+                                   this._baseUrl,
+                                   this._getForwarded(request),
+                                   this._getXForwardHeaders(request),
+                                   { protocol: 'http:', host: request.headers.host });
   }
 
   // Try to handle the request
@@ -52,6 +56,28 @@ Controller.prototype.handleRequest = function (request, response, next, settings
       next(error);
     }
   }
+};
+
+// Get host and protocol from HTTP's Forwarded header
+Controller.prototype._getForwarded = function (request) {
+  if (!request.headers.forwarded)
+    return {};
+  try {
+    var forwarded = _.defaults.apply(this, parseForwarded(request.headers.forwarded));
+    return {
+      protocol: forwarded.proto ? forwarded.proto + ':' : undefined,
+      host: forwarded.host,
+    };
+  }
+  catch (error) { return {}; }
+};
+
+// Get host and protocol from HTTP's X-Forward-* headers
+Controller.prototype._getXForwardHeaders = function (request) {
+  return {
+    protocol: request.headers['x-forward-proto'] ? request.headers['x-forward-proto'] + ':' : undefined,
+    host: request.headers['x-forward-host'],
+  };
 };
 
 // Tries to process the HTTP request in an implementation-specific way

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "asynciterator": "^1.1.0",
+    "forwarded-parse": "^2.0.0",
     "jsonld": "^0.4.11",
     "lodash": "^2.4.2",
     "lru-cache": "^4.0.1",


### PR DESCRIPTION
As discussed in https://github.com/LinkedDataFragments/Client.js/issues/36

@rubensworks This is just a proposal, if you don't like the X-Forward-Host/Proto just let's discuss it.