### PR TITLE
Removed unnecessary ssl key

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,14 +178,7 @@ If you decide to let a proxy handle HTTPS, use this configuration to run the ser
      {
        "protocol": "http",
        "baseURL": "https://data.example.org/",
-       "ssl": {
-         "keys" : {
-           "key": "./private-key-server.key.pem",
-           "ca": ["./root-ca.crt.pem"],
-           "cert": "./server-certificate.crt.pem"
-        }
-      }
-    }  
+     }  
 
 
 ### _(Optional)_ Running in a Docker container


### PR DESCRIPTION
When using a proxy to handle SSL you do not need to set SSL key, ca and cert. Example was a bit confusing because it seemed like the backend server still needed to have ssl configuration.