### PR TITLE
Allow specifying typePath for datasources

### DIFF
--- a/bin/ldf-server
+++ b/bin/ldf-server
@@ -193,7 +193,9 @@ else {
 // Instantiates an object from the given description
 function instantiate(description, includePath) {
   var type = description.type || description,
-      typePath = path.join(includePath ? path.resolve(__dirname, includePath) : '', type),
+      typePath = description.typePath ?
+        path.join(process.cwd(), description.typePath) :
+	path.join(includePath ? path.resolve(__dirname, includePath) : '', type),
       Constructor = constructors[typePath] || (constructors[typePath] = require(typePath)),
       extensions = config.extensions && config.extensions[type] || [],
       settings = _.defaults(description.settings || {}, {


### PR DESCRIPTION
This allows you to create a local (to your config) datasource module by specifying the path to look for it.