### PR TITLE
Extend logging

### DIFF
--- a/bin/ldf-server
+++ b/bin/ldf-server
@@ -158,10 +158,13 @@ else {
   if (loggingSettings.enabled) {
     var accesslog = require('access-log');
     config.accesslogger = function (request, response) {
-      accesslog(request, response, null, function (logEntry) {
-        fs.appendFile(loggingSettings.file, logEntry + '\n', function (error) {
-          error && process.stderr.write('Error when writing to access log file: ' + error);
-        });
+      accesslog(request, response, loggingSettings.format, function (logEntry) {
+        if (loggingSettings.file) {
+          fs.appendFile(loggingSettings.file, logEntry + '\n', function (error) {
+            error && process.stderr.write('Error when writing to access log file: ' + error);
+          });
+        }
+        else console.log(logEntry);
       });
     };
   }

--- a/config/config-defaults.json
+++ b/config/config-defaults.json
@@ -55,5 +55,9 @@
     }
   },
 
-  "logging": { "enabled": false, "file": "access.log" }
+  "logging": {
+    "enabled": false,
+    "file": "access.log",
+    "format": null
+  }
 }


### PR DESCRIPTION
Support logging to STDOUT via setting `logging.file` to `false` and
customization of log format with `logging.format`. The default value
`null` falls back to default format. Custom format is required for
proper logging behind a reverse proxy to log the remote IP from HTTP
header `X-Forwarded-For` instead of the proxy IP.