### PR TITLE
Remove Google fonts

### DIFF
--- a/lib/views/base.html
+++ b/lib/views/base.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <title><%= title || header || 'Linked Data Fragments Server' %></title>
   <link rel="stylesheet" href="<%= assetsPath %>styles/ldf-server" />
-  <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:700italic,400,700|Droid+Sans+Mono" type="text/css" />
   <meta name="viewport" content="width=device-width,minimum-scale=1,maximum-scale=1">
 </head>
 <body>


### PR DESCRIPTION
There is no need to direct all access to Google servers. The HTML looks fine without this fonts and without possible privacy violation.