### PR TITLE
Log initialized data sources

### DIFF
--- a/bin/ldf-server
+++ b/bin/ldf-server
@@ -169,9 +169,13 @@ else {
   // Create server, and start it when all data sources are ready
   var server = new LinkedDataFragmentsServer(config),
       pending = _.size(datasources);
-  _.each(datasources, function (settings) {
+  Object.keys(datasources).forEach(function (datasourceName) {
+    var settings = datasources[datasourceName]
     var ready = _.once(startWhenReady);
-    settings.datasource.once('initialized', ready);
+    settings.datasource.once('initialized', function () {
+      console.log("Initialized %s (%d pending)", datasourceName, pending)
+      ready()
+    });
     settings.datasource.once('error', ready);
   });
   function startWhenReady() {

--- a/bin/ldf-server
+++ b/bin/ldf-server
@@ -173,8 +173,8 @@ else {
     var settings = datasources[datasourceName]
     var ready = _.once(startWhenReady);
     settings.datasource.once('initialized', function () {
-      console.log("Initialized %s (%d pending)", datasourceName, pending)
-      ready()
+      console.log("Initialized %s (%d pending)", datasourceName, pending);
+      ready();
     });
     settings.datasource.once('error', ready);
   });


### PR DESCRIPTION
Show which data source has been initialized and how many are pending. The message may be extended with the number of triples.