### PR TITLE
Update example SPARQL datasources to public DBpedia endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ and a [SPARQL endpoint](http://www.w3.org/TR/sparql11-protocol/) as sources:
       "title": "DBpedia 3.9 (Virtuoso)",
       "type": "SparqlDatasource",
       "description": "DBpedia 3.9 with a Virtuoso back-end",
-      "settings": { "endpoint": "http://dbpedia.restdesc.org/", "defaultGraph": "http://dbpedia.org" }
+      "settings": { "endpoint": "https://dbpedia.org/sparql", "defaultGraph": "http://dbpedia.org" }
     }
   }
 }

--- a/config/config-example-advanced.json
+++ b/config/config-example-advanced.json
@@ -17,7 +17,7 @@
       "title": "DBpedia 3.9 (Virtuoso)",
       "type": "SparqlDatasource",
       "description": "DBpedia 3.9 with a Virtuoso back-end",
-      "settings": { "endpoint": "http://dbpedia.restdesc.org/", "defaultGraph": "http://dbpedia.org" }
+      "settings": { "endpoint": "https://dbpedia.org/sparql", "defaultGraph": "http://dbpedia.org" }
     }
   },
 

--- a/config/config-example.json
+++ b/config/config-example.json
@@ -12,7 +12,7 @@
       "title": "DBpedia 3.9 (Virtuoso)",
       "type": "SparqlDatasource",
       "description": "DBpedia 3.9 with a Virtuoso back-end",
-      "settings": { "endpoint": "http://dbpedia.restdesc.org/", "defaultGraph": "http://dbpedia.org" }
+      "settings": { "endpoint": "https://dbpedia.org/sparql", "defaultGraph": "http://dbpedia.org" }
     }
   },
 


### PR DESCRIPTION
Because http://dbpedia.restdesc.org/ is not available anymore.