### PR TITLE
Update Dockerfile to set WORKDIR before run npm install

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16-slim
-
+LABEL description="Triple Pattern Fragment Server."
 # Install location
 ENV dir /var/www/@ldf/server
 
@@ -16,15 +16,17 @@ RUN npm config set @ldf:registry $NPM_REGISTRY
 # Install the node module
 RUN apt-get update && \
     apt-get install -y g++ make python && \
-    cd ${dir} && npm install --only=production && \
-    apt-get remove -y g++ make python && apt-get autoremove -y && \
+    cd ${dir} 
+
+WORKDIR ${dir}
+RUN npm install --only=production 
+RUN apt-get remove -y g++ make python && apt-get autoremove -y && \
     rm -rf /var/cache/apt/archives
 
 # Expose the default port
 EXPOSE 3000
 
 # Run base binary
-WORKDIR ${dir}
 ENTRYPOINT ["node", "bin/ldf-server"]
 
 # Default command


### PR DESCRIPTION
When no WORKDIR is specified, npm install is executed in the root directory of the container, which was resulting in the error: 

[npm ERR! Tracker "idealTree" already exists while creating the Docker image for Node project](https://stackoverflow.com/questions/57534295/npm-err-tracker-idealtree-already-exists-while-creating-the-docker-image-for)

