### PR TITLE
Fix invalid baseIRI warning due to missing file prefix

### DIFF
--- a/packages/core/lib/datasources/MemoryDatasource.js
+++ b/packages/core/lib/datasources/MemoryDatasource.js
@@ -9,6 +9,12 @@ class MemoryDatasource extends Datasource {
   constructor(options) {
     let supportedFeatureList = ['quadPattern', 'triplePattern', 'limit', 'offset', 'totalCount'];
     super(options, supportedFeatureList);
+    if (options.file) {
+      if (!options.file.startsWith('file://') && !options.file.startsWith('http://') && !options.file.startsWith('https://'))
+        options.file = `file://${options.file}`;
+    }
+
+    this._url = options && (options.url || options.file);
   }
 
   // Prepares the datasource for querying

--- a/packages/datasource-jsonld/lib/datasources/JsonLdDatasource.js
+++ b/packages/datasource-jsonld/lib/datasources/JsonLdDatasource.js
@@ -10,12 +10,6 @@ let ACCEPT = 'application/ld+json;q=1.0,application/json;q=0.7';
 class JsonLdDatasource extends MemoryDatasource {
   constructor(options) {
     super(options);
-    if (options.file) {
-      if (!options.file.startsWith('file://'))
-        options.file = `file://${options.file}`;
-    }
-
-    this._url = options && (options.url || options.file);
   }
 
   // Retrieves all quads from the document

--- a/packages/datasource-jsonld/lib/datasources/JsonLdDatasource.js
+++ b/packages/datasource-jsonld/lib/datasources/JsonLdDatasource.js
@@ -10,6 +10,11 @@ let ACCEPT = 'application/ld+json;q=1.0,application/json;q=0.7';
 class JsonLdDatasource extends MemoryDatasource {
   constructor(options) {
     super(options);
+    if (options.file) {
+      if (!options.file.startsWith('file://'))
+        options.file = `file://${options.file}`;
+    }
+
     this._url = options && (options.url || options.file);
   }
 

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16-slim
-
+LABEL description="Triple Pattern Fragment Server."
 # Install location
 ENV dir /var/www/@ldf/server
 
@@ -16,15 +16,17 @@ RUN npm config set @ldf:registry $NPM_REGISTRY
 # Install the node module
 RUN apt-get update && \
     apt-get install -y g++ make python && \
-    cd ${dir} && npm install --only=production && \
-    apt-get remove -y g++ make python && apt-get autoremove -y && \
+    cd ${dir} 
+
+WORKDIR ${dir}
+RUN npm install --only=production 
+RUN apt-get remove -y g++ make python && apt-get autoremove -y && \
     rm -rf /var/cache/apt/archives
 
 # Expose the default port
 EXPOSE 3000
 
 # Run base binary
-WORKDIR ${dir}
 ENTRYPOINT ["node", "bin/ldf-server"]
 
 # Default command

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16-slim
-LABEL description="A Docker Image for Triple Pattern Fragment Server (NodeJS)"
+LABEL description="Triple Pattern Fragment Server."
 # Install location
 ENV dir /var/www/@ldf/server
 

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:16-slim
-LABEL description="Triple Pattern Fragment Server."
+LABEL description="A Docker Image for Triple Pattern Fragment Server (NodeJS)"
 # Install location
 ENV dir /var/www/@ldf/server
 


### PR DESCRIPTION
While creating a JSON-LD datasource using a path without the prefix `file://` it was raising a warning message: 
`WARNING: skipped datasource {datasource_name}. Found invalid baseIRI '/path_to_file.jsonld' for value '/path_to_file.jsonld'`

This fix prepend `file://` while instantiating a JSONLD datasource.

----------
### Update
This issue was extended to fix the problem not just in JSON-LD but in all Memory datasources.